### PR TITLE
Apply limit and sorting to graphql queries

### DIFF
--- a/dapp-v1/queries.graphql
+++ b/dapp-v1/queries.graphql
@@ -21,6 +21,8 @@ query ManageLendingDesks(
 ) {
   lendingDesks(
     where: { ownerId: $walletAddress, status: $status }
+    orderBy: "id"
+    orderDirection: "desc"
     after: $after
     limit: 10
   ) {
@@ -105,11 +107,14 @@ query ManageLendingDesk($deskId: String!) {
 query BrowseCollections($after: String) {
   nftCollections(
     where: { activeLoanConfigsCount_gt: "0" }
+    orderBy: "activeLoanConfigsCount"
+    orderDirection: "desc"
     after: $after
     limit: 100
   ) {
     items {
       id
+      activeLoanConfigsCount
       loanConfigs {
         items {
           lendingDesk {
@@ -236,6 +241,8 @@ query BorrowerDashboard(
 ) {
   loans(
     where: { borrowerId: $walletAddress, status: $status }
+    orderBy: "startTime"
+    orderDirection: "desc"
     after: $after
     limit: 15
   ) {
@@ -276,6 +283,8 @@ query LenderDashboard(
 ) {
   loans(
     where: { lenderId: $walletAddress, status: $status }
+    orderBy: "startTime"
+    orderDirection: "desc"
     after: $after
     limit: 15
   ) {


### PR DESCRIPTION
### Current limits applied
ManageLendingDesks: **10**
BrowseCollections: **100**
BrowseCollection: **500**
QuickLoan: **50**
BorrowerDashboard: **15**
LenderDashboard: **15**

### Current sorting applied (order by, order direction)
ManageLendingDesks: **id, desc**
BrowseCollections: **active loan configs count, desc**
BrowseCollection: **balance, desc**
QuickLoan: **balance, desc**
BorrowerDashboard: **startTime, desc**
LenderDashboard: **startTime, desc**
